### PR TITLE
Only run checks on push and pull request to master

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,5 +1,9 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
+    branches: [ $default-branch ]
 
 jobs:
   test:
@@ -8,7 +12,7 @@ jobs:
     steps:
       - run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - uses: actions/checkout@v3
-      - run: cargo test --all
+      - run: cargo test --all --verbose
 
   format:
     runs-on: ubuntu-latest
@@ -16,7 +20,7 @@ jobs:
     steps:
       - run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - uses: actions/checkout@v3
-      - run: cargo fmt --all -- --check
+      - run: cargo fmt --all -- --check --verbose
 
   clippy:
     runs-on: ubuntu-latest
@@ -24,4 +28,4 @@ jobs:
     steps:
       - run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - uses: actions/checkout@v3
-      - run: cargo clippy --all -- -D warnings
+      - run: cargo clippy --all -- -D warnings --verbose


### PR DESCRIPTION
This prevents (hopefully!) GH from running all checks twice for each PR.